### PR TITLE
Handle messages longer than 4096 bytes.

### DIFF
--- a/boardplayer/player.py
+++ b/boardplayer/player.py
@@ -20,7 +20,9 @@ class Client(object):
         self.socket = socket.create_connection((self.addr, self.port))
         self.running = True
         while self.running:
-            message = self.socket.recv(4096)
+            message = ''
+            while not message.endswith('\r\n'):
+                message += self.socket.recv(4096)
             messages = message.rstrip().split('\r\n')
             for message in messages:
                 data = json.loads(message)


### PR DESCRIPTION
Thanks for sharing the project. I suspect your switch to JSON made the messages longer. Now, I can't finish a game of Ultimate Tic-Tac-Toe without a crash.

This patch keeps reading the message until it ends with `\r\n`.